### PR TITLE
Init and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ ido.last
 ac-comphist.dat
 history
 recentf
-etc/custom.el
+custom.el
+transient/
+forge-database.sqlite

--- a/config.org
+++ b/config.org
@@ -25,46 +25,16 @@ cheatsheets all here.
 
 *** plumbing
 
-    To tell emacs that all saves should go to the ~/.backups~ folder.
+    Tell emacs that all saves should go to the ~/.backups~ folder.
 
 #+BEGIN_SRC emacs-lisp
 (setq backup-directory-alist `(("." . "~/.backups")))
-(defalias 'yes-or-no-p 'y-or-n-p)
 #+END_SRC
-*** ~use-package~
 
-   I manage all the packages for my emacs configuration through the
-   fantastic [[https://github.com/jwiegley/use-package][use-package]]. Here's how to get it:
+    Tell emacs that y or n will suffice.
 
 #+BEGIN_SRC emacs-lisp
-
-(require 'package)
-
-(setq package-enable-at-startup nil)
-(add-to-list 'package-archives '("gnu" . "http://elpa.gnu.org/packages/"))
-(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
-(add-to-list 'package-archives '("marmalade" . "http://marmalade-repo.org/packages/"))
-(add-to-list 'package-archives '("melpa-stable" . "http://stable.melpa.org/packages/"))
-(package-initialize)
-
-(when (not (package-installed-p 'paradox))
-  (package-install 'paradox))
-
-(paradox-require 'use-package)
-
-(require 'use-package)
-
-(setq use-package-always-ensure t)
-
-
-;(unless (package-installed-p 'use-package)
-;  (package-refresh-contents)
-;  (package-install 'use-package))
-
-;(eval-when-compile
-;  (require 'use-package))
-
-(require 'bind-key)
+(defalias 'yes-or-no-p 'y-or-n-p)
 #+END_SRC
 
 *** Appearance
@@ -76,15 +46,18 @@ cheatsheets all here.
  'default nil :family "Operator Mono"
  :height 160)
 #+END_SRC
+
 *** Just load themes
+
 I accept the risk. Theme tooltips too.
 #+BEGIN_SRC emacs-lisp
 (setq custom-safe-themes t)
 (setq x-gtk-use-system-tooltips nil)
 #+END_SRC
+
 *** maintaining selected theme between sessions
 
-    I think I got all this from @anler, but am not sure :)
+    I got this from @pepegar[fn:1], and he thinks he got it from @anler[fn:2].
 
 #+BEGIN_SRC emacs-lisp
 (defun my-load-saved-theme ()
@@ -121,7 +94,10 @@ I accept the risk. Theme tooltips too.
       (write-region (point-min)
                     (point-max)
                     my-saved-theme-filename))))
+#+END_SRC
 
+*** Reload configuration via function
+#+BEGIN_SRC emacs-lisp
 ;; if you make changes to config.org, simply M-x load-config to reload
 (defun load-config ()
   (interactive)
@@ -137,15 +113,12 @@ I accept the risk. Theme tooltips too.
 #+BEGIN_SRC emacs-lisp
 (use-package magit
   :ensure t
-  :config
-
-  (use-package magit-gh-pulls
-    :ensure t
-    :init
-    (add-hook 'magit-mode-hook 'turn-on-magit-gh-pulls))
   :commands magit-status
   :bind ("C-x g" . magit-status)
 )
+
+(use-package forge)
+
 #+END_SRC
 
     There are several tricks I like to do with Magit.
@@ -161,24 +134,6 @@ I accept the risk. Theme tooltips too.
      ~master~), and then within the magit screen, I just hit ~b s~,
      making a spinoff of master, with the last commits.  This is so
      convenient :)
-
-**** managing/creating pull requests
-
-     For creating pull requests, I use the ~magit-gh-pulls~ package,
-     that connects to the github API via HTTP and allows me to create,
-     list, and see the Pull Requests for the repo.
-
-     Normally I need to edit the ~.git/config~ file and add the remote
-     github repo:
-
-#+BEGIN_SRC
-[magit]
-        gh-pulls-repo = jeffusan/$repo
-#+END_SRC
-
-     After that's set, I can just ~# g~ to refresh the latest pull
-     requests, ~# o~ on a pr of the list to open in firefox, or ~# c~
-     to create a new PR from the existing changes.
 
 *** Projectile
 #+BEGIN_SRC emacs-lisp
@@ -215,6 +170,7 @@ I accept the risk. Theme tooltips too.
   :config
   (autopair-global-mode))
 #+END_SRC
+
 *** Hydra
 
     Hydra allows me to create menus of keybindings.  I have several
@@ -382,6 +338,7 @@ I accept the risk. Theme tooltips too.
   :ensure t
   :config (golden-ratio-mode))
 #+END_SRC
+
 *** Eshell Configuration
 #+BEGIN_SRC emacs-lisp
 (global-set-key (kbd "C-c e") 'eshell)
@@ -464,6 +421,7 @@ For extending the search to the next word, use M-j.
   :bind (("C-s" . swiper)
          ("C-;" . swiper-avy)))
 #+END_SRC
+
 ** Themes
 
    I switch between a big number of themes, sometimes several times a
@@ -492,12 +450,6 @@ For extending the search to the next word, use M-j.
 (use-package madhat2r-theme :ensure t :defer t)
 (use-package kosmos-theme :ensure t :defer t)
 (use-package nord-theme :ensure t :defer t)
-#+END_SRC
-
-** Some more configuration for when all packages have been loaded
-
-#+BEGIN_SRC emacs-lisp
-(require 'bind-key)
 #+END_SRC
 
 ** Programming languages
@@ -543,25 +495,38 @@ For extending the search to the next word, use M-j.
 
 #+END_SRC
 
+** Some more configuration for when all packages have been loaded
+
+#+BEGIN_SRC emacs-lisp
+(require 'bind-key)
+#+END_SRC
+
 ** Thanks
 
-Most of this is borrowed configuration from others.
+Most of this is borrowed configuration from others. I thank them here, but 
+also check the Footnotes.
 
-- Thanks to Pepe Garcia, https://github.com/pepegar
-- and Bodil Stokke, https://github.com/bodil
-in particular.
+Thanks to Pepe Garcia[fn:1], most of this is his.
 
-Also 
-- [fn:2]anler
-- [fn:3]danielmai
-- [fn:4]jwiegley
-- [fn:5]abo-abo
-
+Also Bodil Stokke[fn:7]; ohai emacs remains an inspiration.
 
 * Footnotes
 
-[fn:1] https://github.com/pashky/restclient.el
+[fn:1] https://github.com/pepegar/.emacs.d
 [fn:2] https://github.com/anler/.emacs.d
 [fn:3] https://github.com/danielmai
 [fn:4] https://github.com/jwiegley
 [fn:5] https://github.com/abo-abo
+[fn:6] https://github.com/pashky/restclient.el
+[fn:7] https://github.com/bodil
+
+* Thanks
+
+While this emacs config is largely derived from Pepe Garcia, 
+I have a long list of Emacs friends to thank.
+Coincidentally they all have their own websites:
+
+- Julian Danjou: https://julien.danjou.info/
+- Just Ambrahms: https://justin.abrah.ms/
+- Steve Purcell: https://www.sanityinc.com/
+- Bodil Stokke: https://bodil.lol/

--- a/config.org
+++ b/config.org
@@ -2,11 +2,6 @@
 
 This is my emacs configuration in Org mode.
 
-The idea behind using org mode for this is that I can get rid of all
-these cheatsheets I've flying around my system (and also physical
-desk) and have both the emacs-lisp code, the notes, and the
-cheatsheets all here.
-
 ** Initial configuration
 *** Some personal information
 
@@ -18,9 +13,12 @@ cheatsheets all here.
 *** Help emacs find my executables
 
 #+BEGIN_SRC emacs-lisp
-(setq exec-path (append exec-path '("/usr/local/bin")))
-(setq exec-path (append exec-path '("/home/jeff/bin")))
-(setq exec-path (append exec-path '("/home/jeff/go/bin")))
+(setq exec-path 
+    (append exec-path 
+        (list 
+            '("/usr/local/bin") 
+            '("/home/jeff/bin") 
+            '("/home/jeff/go/bin"))))
 #+END_SRC
 
 *** plumbing
@@ -39,8 +37,11 @@ cheatsheets all here.
 
     Set custom settings in their own file
 #+BEGIN_SRC emacs-lisp
-(setq custom-file "~/.emacs.d/custom.el")
-(load custom-file)
+;; Figure out the path to our .emacs.d by getting the path part of the
+;; current file (`init.el`).
+(setq dotfiles-dir (file-name-directory (or (buffer-file-name) (file-chase-links load-file-name))))
+(setq custom-file (concat dotfiles-dir "custom.el"))
+(load custom-file 'noerror)
 #+END_SRC
 
 *** Appearance
@@ -114,8 +115,6 @@ I accept the risk. Theme tooltips too.
 ** Tools
 *** Magit
 
-    Magit is a better way to use git, from within emacs, of course.
-
 #+BEGIN_SRC emacs-lisp
 (use-package magit
   :ensure t
@@ -126,20 +125,6 @@ I accept the risk. Theme tooltips too.
 (use-package forge)
 
 #+END_SRC
-
-    There are several tricks I like to do with Magit.
-
-**** commit & spinoff branch
-
-     Normally, when I work on a small patch for a project I don't
-     directly start creating the feature branch, but first create the
-     commit/commits that solve the issue and then create the branch &
-     pull request.
-
-     I do this by fixing and creating the commits normally (on top of
-     ~master~), and then within the magit screen, I just hit ~b s~,
-     making a spinoff of master, with the last commits.  This is so
-     convenient :)
 
 *** Projectile
 #+BEGIN_SRC emacs-lisp
@@ -187,7 +172,6 @@ I accept the risk. Theme tooltips too.
 (use-package hydra
   :ensure t
   :bind (("C-x t" . toggle/body)
-	 ("C-x j" . gotoline/body)
          ("C-x ," . scala/body)
 	 ("C-x p" . dotfiles/body))
   :config
@@ -208,19 +192,6 @@ I accept the risk. Theme tooltips too.
     ("t" toggle-truncate-lines "truncate")
     ("w" whitespace-mode "whitespace")
     ("q" nil "cancel"))
-
-  (defhydra gotoline
-    ( :pre (linum-mode 1)
-	   :post (linum-mode -1))
-    "goto"
-    ("t" (lambda () (interactive)(move-to-window-line-top-bottom 0)) "top")
-    ("b" (lambda () (interactive)(move-to-window-line-top-bottom -1)) "bottom")
-    ("m" (lambda () (interactive)(move-to-window-line-top-bottom)) "middle")
-    ("e" (lambda () (interactive)(end-of-buffer)) "end")
-    ("c" recenter-top-bottom "recenter")
-    ("n" next-line "down")
-    ("p" (lambda () (interactive) (forward-line -1))  "up")
-    ("g" goto-line "goto-line")))
 
   (defhydra dotfiles (:color black)
     "dotfiles"
@@ -246,7 +217,7 @@ I accept the risk. Theme tooltips too.
     | ~C-c C-.~  | mark the query under the cursor                                                                |
     | ~C-c C-u~  | copy query under the cursor as a curl command                                                  |
     | ~C-c C-g~  | start a helm session with sources for variables and requests (if helm is available, of course) |
-    | ~C-c n n~  | narrow to regi                                                                                 |
+    | ~C-c n n~  | narrow to region                                                                               |
 
 #+BEGIN_SRC emacs-lisp
 (use-package restclient
@@ -255,9 +226,6 @@ I accept the risk. Theme tooltips too.
 #+END_SRC
 
 *** Org mode
-
-    I try to write down everything in org mode, and to keep it
-    updated.  This is my current configuration.
 
 #+BEGIN_SRC emacs-lisp
 (use-package org
@@ -430,10 +398,6 @@ For extending the search to the next word, use M-j.
 
 ** Themes
 
-   I switch between a big number of themes, sometimes several times a
-   day, depending on my mood.  The ones I stick with as of now, are
-   the following:
-
 #+BEGIN_SRC emacs-lisp
 (use-package doom-themes :pin melpa-stable :ensure t :defer t)
 (use-package idea-darkula-theme :ensure t :defer t)
@@ -459,9 +423,6 @@ For extending the search to the next word, use M-j.
 #+END_SRC
 
 ** Programming languages
-
-   At the time of writing this, I mostly write scala, but I've used a
-   number of languages previously:
 
 #+BEGIN_SRC emacs-lisp
 (use-package ensime
@@ -525,14 +486,3 @@ Also Bodil Stokke[fn:7]; ohai emacs remains an inspiration.
 [fn:5] https://github.com/abo-abo
 [fn:6] https://github.com/pashky/restclient.el
 [fn:7] https://github.com/bodil
-
-* Thanks
-
-While this emacs config is largely derived from Pepe Garcia, 
-I have a long list of Emacs friends to thank.
-Coincidentally they all have their own websites:
-
-- Julian Danjou: https://julien.danjou.info/
-- Just Ambrahms: https://justin.abrah.ms/
-- Steve Purcell: https://www.sanityinc.com/
-- Bodil Stokke: https://bodil.lol/

--- a/config.org
+++ b/config.org
@@ -37,6 +37,12 @@ cheatsheets all here.
 (defalias 'yes-or-no-p 'y-or-n-p)
 #+END_SRC
 
+    Set custom settings in their own file
+#+BEGIN_SRC emacs-lisp
+(setq custom-file "~/.emacs.d/custom.el")
+(load custom-file)
+#+END_SRC
+
 *** Appearance
 
     Select the font size, family...

--- a/init.el
+++ b/init.el
@@ -1,7 +1,10 @@
-;;
-;; This file is adapted from @danielmai's ~init.el~
-;;
+(setq debug-on-error t)
+
+
+;; Adjust garbage collection thresholds during startup, and thereafter
 (setq gc-cons-threshold 400000000)
+
+(package-initialize)
 
 ;;; Begin initialization
 ;; Turn off mouse interface early in startup to avoid momentary display
@@ -11,24 +14,43 @@
   (scroll-bar-mode -1)
   (tooltip-mode -1))
 
+;; Skip the splash screen
 (setq inhibit-startup-message t)
-(setq initial-scratch-message "Blessed art thou, who hath come to the One True Editor.")
-(setq initial-major-mode 'emacs-lisp-mode)
 
 ;;; Set up package
 (require 'package)
-(add-to-list 'package-archives
-             '("melpa" . "http://melpa.org/packages/") t)
+(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/") t)
 (add-to-list 'package-archives '("org" . "http://orgmode.org/elpa/") t)
-(when (boundp 'package-pinned-packages)
-  (setq package-pinned-packages
-        '((org-plus-contrib . "org"))))
-(package-initialize)
+(add-to-list 'package-archives '("gnu" . "http://elpa.gnu.org/packages/") t)
+(add-to-list 'package-archives '("marmalade" . "http://marmalade-repo.org/packages/") t)
+(add-to-list 'package-archives '("melpa-stable" . "http://stable.melpa.org/packages/") t)
 
+(package-initialize)
+;; (package-refresh-contents)
+
+(package-install 'paradox)
+
+(paradox-require 'use-package)
+
+(require 'use-package)
+
+(setq use-package-always-ensure t)
 
 ;;; Load the config
 (org-babel-load-file (concat user-emacs-directory "config.org"))
 
 (setq gc-cons-threshold 800000)
-(setq custom-file "~/.emacs.d/etc/custom.el")
-(load custom-file)
+(custom-set-variables
+ ;; custom-set-variables was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ '(package-selected-packages
+   (quote
+    (forge magit-popup magit-gh-pulls flycheck go-complete go-eldoc go-mode auto-complete ensime nord-theme kosmos-theme madhat2r-theme sublime-themes subatomic-theme soothe-theme plan9-theme heroku-theme github-theme espresso-theme cyberpunk-theme bliss-theme birds-of-paradise-plus-theme atom-one-dark-theme arjen-grey-theme white-theme punpun-theme idea-darkula-theme doom-themes neotree counsel-projectile counsel flx ivy yaml-mode terraform-mode exec-path-from-shell golden-ratio expand-region org-bullets restclient autopair projectile magit use-package paradox))))
+(custom-set-faces
+ ;; custom-set-faces was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ )

--- a/init.el
+++ b/init.el
@@ -40,17 +40,3 @@
 (org-babel-load-file (concat user-emacs-directory "config.org"))
 
 (setq gc-cons-threshold 800000)
-(custom-set-variables
- ;; custom-set-variables was added by Custom.
- ;; If you edit it by hand, you could mess it up, so be careful.
- ;; Your init file should contain only one such instance.
- ;; If there is more than one, they won't work right.
- '(package-selected-packages
-   (quote
-    (yaml-tomato forge magit-popup magit-gh-pulls flycheck go-complete go-eldoc go-mode auto-complete ensime nord-theme kosmos-theme madhat2r-theme sublime-themes subatomic-theme soothe-theme plan9-theme heroku-theme github-theme espresso-theme cyberpunk-theme bliss-theme birds-of-paradise-plus-theme atom-one-dark-theme arjen-grey-theme white-theme punpun-theme idea-darkula-theme doom-themes neotree counsel-projectile counsel flx ivy yaml-mode terraform-mode exec-path-from-shell golden-ratio expand-region org-bullets restclient autopair projectile magit use-package paradox))))
-(custom-set-faces
- ;; custom-set-faces was added by Custom.
- ;; If you edit it by hand, you could mess it up, so be careful.
- ;; Your init file should contain only one such instance.
- ;; If there is more than one, they won't work right.
- )

--- a/init.el
+++ b/init.el
@@ -47,7 +47,7 @@
  ;; If there is more than one, they won't work right.
  '(package-selected-packages
    (quote
-    (forge magit-popup magit-gh-pulls flycheck go-complete go-eldoc go-mode auto-complete ensime nord-theme kosmos-theme madhat2r-theme sublime-themes subatomic-theme soothe-theme plan9-theme heroku-theme github-theme espresso-theme cyberpunk-theme bliss-theme birds-of-paradise-plus-theme atom-one-dark-theme arjen-grey-theme white-theme punpun-theme idea-darkula-theme doom-themes neotree counsel-projectile counsel flx ivy yaml-mode terraform-mode exec-path-from-shell golden-ratio expand-region org-bullets restclient autopair projectile magit use-package paradox))))
+    (yaml-tomato forge magit-popup magit-gh-pulls flycheck go-complete go-eldoc go-mode auto-complete ensime nord-theme kosmos-theme madhat2r-theme sublime-themes subatomic-theme soothe-theme plan9-theme heroku-theme github-theme espresso-theme cyberpunk-theme bliss-theme birds-of-paradise-plus-theme atom-one-dark-theme arjen-grey-theme white-theme punpun-theme idea-darkula-theme doom-themes neotree counsel-projectile counsel flx ivy yaml-mode terraform-mode exec-path-from-shell golden-ratio expand-region org-bullets restclient autopair projectile magit use-package paradox))))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.

--- a/init.el
+++ b/init.el
@@ -26,7 +26,8 @@
 (add-to-list 'package-archives '("melpa-stable" . "http://stable.melpa.org/packages/") t)
 
 (package-initialize)
-;; (package-refresh-contents)
+ (unless package-archive-contents (package-refresh-contents))
+;(package-refresh-contents)
 
 (package-install 'paradox)
 


### PR DESCRIPTION
Custom settings are generated in their own custom.el, which is git ignored. If custom.el does not exist it should be created- this will happen in config.org but not in init.el. 

magit-popup references a deprecated library and may cause problems, I removed most references to it and haven't had issues.

Package initialization and configuration is now in init.el. A fresh install will prompt to accept certificates.